### PR TITLE
2 maincpp validate argv port and password

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,7 +6,7 @@
 /*   By: leoaguia <leoaguia@student.42porto.com>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2026/09/01 18:52:15 by leoaguia          #+#    #+#             */
-/*   Updated: 2026/09/02 03:29:48 by leoaguia         ###   ########.fr       */
+/*   Updated: 2026/09/02 03:38:55 by leoaguia         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -84,7 +84,7 @@ int	main(int argc, char **argv)
 		validatePass(pass);
 
 		// 2. Constrói o Server: socket, bind, listen. Lança se algum falhar.
-		// Server	server(port, password);
+		// Server	server(port, pass);
 
 		// 3. Entra no loop de poll(). Só retorna no SIGINT.
 		// server.run()

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,7 +6,7 @@
 /*   By: leoaguia <leoaguia@student.42porto.com>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2026/09/01 18:52:15 by leoaguia          #+#    #+#             */
-/*   Updated: 2026/09/02 03:21:16 by leoaguia         ###   ########.fr       */
+/*   Updated: 2026/09/02 03:29:48 by leoaguia         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -26,8 +26,8 @@ static void	validatePass(const std::string& pass)
 }
 
 // Valida e converte a porta:
-// - 1 a 5 dígitos
 // - Somente dígitos
+// - 1 a 5 dígitos
 // - Valor entre 1024 e 65535 (0~1023 = well-known ports e 65535 = limite 16 bits)
 static int	validatePort(const std::string& port)
 {
@@ -37,16 +37,17 @@ static int	validatePort(const std::string& port)
 	if (port.empty())
 		throw std::invalid_argument("port must not be empty");
 
-	// 2. 1 a 5 dígitos
-	if (port.size() > 5)
-		throw std::invalid_argument("port is too long: " + port);
-
-	// 3. Somente dígitos
+	// 2. Somente dígitos
 	for (std::string::size_type i = 0; i < port.size(); ++i)
 	{
 		if (port[i] < '0' || port[i] > '9')
 			throw std::invalid_argument("port must contain digits only: " + port);
 	}
+
+	// 3. 1 a 5 dígitos
+	if (port.size() > 5)
+		throw std::invalid_argument("port is too long: " + port);
+
 
 	// 4. Conversão (string -> int)
 	value = 0;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,7 +6,7 @@
 /*   By: leoaguia <leoaguia@student.42porto.com>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2026/09/01 18:52:15 by leoaguia          #+#    #+#             */
-/*   Updated: 2026/09/02 03:38:55 by leoaguia         ###   ########.fr       */
+/*   Updated: 2026/09/02 03:43:40 by leoaguia         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -83,10 +83,10 @@ int	main(int argc, char **argv)
 
 		validatePass(pass);
 
-		// 2. Constrói o Server: socket, bind, listen. Lança se algum falhar.
+		// 3. Constrói o Server: socket, bind, listen. Lança se algum falhar.
 		// Server	server(port, pass);
 
-		// 3. Entra no loop de poll(). Só retorna no SIGINT.
+		// 4. Entra no loop de poll(). Só retorna no SIGINT.
 		// server.run()
 
 		// TODO: remover quando o Server existir (issue #3)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,14 +6,100 @@
 /*   By: leoaguia <leoaguia@student.42porto.com>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2026/09/01 18:52:15 by leoaguia          #+#    #+#             */
-/*   Updated: 2026/09/01 18:53:37 by leoaguia         ###   ########.fr       */
+/*   Updated: 2026/09/02 03:21:16 by leoaguia         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 // main.cpp
 
-// stub just to test compilation
-int	main(void)
+#include <iostream>   // std::cerr, std::endl
+#include <string>     // std::string
+#include <stdexcept>  // std::invalid_argument, std::exception
+
+// #include "Server.hpp"   // TODO: descomentar quando a issue #3 entrar na main
+
+// Valida a senha: Não pode estar vazia
+static void	validatePass(const std::string& pass)
 {
+	if (pass.empty())
+		throw std::invalid_argument("password must not be empty");
+}
+
+// Valida e converte a porta:
+// - 1 a 5 dígitos
+// - Somente dígitos
+// - Valor entre 1024 e 65535 (0~1023 = well-known ports e 65535 = limite 16 bits)
+static int	validatePort(const std::string& port)
+{
+	int	value;
+
+	// 1. Porta vazia
+	if (port.empty())
+		throw std::invalid_argument("port must not be empty");
+
+	// 2. 1 a 5 dígitos
+	if (port.size() > 5)
+		throw std::invalid_argument("port is too long: " + port);
+
+	// 3. Somente dígitos
+	for (std::string::size_type i = 0; i < port.size(); ++i)
+	{
+		if (port[i] < '0' || port[i] > '9')
+			throw std::invalid_argument("port must contain digits only: " + port);
+	}
+
+	// 4. Conversão (string -> int)
+	value = 0;
+	for (std::string::size_type i = 0; i < port.size(); ++i)
+	{
+		value = value * 10 + (port[i] - '0');
+	}
+
+
+	// 5. Intervalo correto (0~1023 não pode e nem maiores que 16 bit)
+	if (value < 1024 || value > 65535)
+		throw std::invalid_argument("port must be between 1024 and 65535");
+
+	return (value);
+}
+
+// Validação dos argumentos e ponto de entrada do servidor.
+int	main(int argc, char **argv)
+{
+	// 1. Ensinar ao usuário
+	if (argc != 3)
+	{
+		std::cerr << "Usage: " << argv[0] << " <port> <password>" << std::endl;
+		return (1);
+	}
+
+	try
+	{
+		// 2. Valida os argumentos. Qualquer problema vira exceção e cai no catch.
+		int			port = validatePort(argv[1]);
+
+		std::string	pass = argv[2];
+
+		validatePass(pass);
+
+		// 2. Constrói o Server: socket, bind, listen. Lança se algum falhar.
+		// Server	server(port, password);
+
+		// 3. Entra no loop de poll(). Só retorna no SIGINT.
+		// server.run()
+
+		// TODO: remover quando o Server existir (issue #3)
+		std::cout	<< "arguments ok: port " << port
+					<< ", pass size " << pass.size() << std::endl;
+	}
+	catch (const std::exception& e)
+	{
+		// Um único ponto de saída para erro. Capturar por referência a
+		// std::exception pega invalid_argument, runtime_error, bad_alloc e
+		// qualquer exceção padrão que o Server venha a lançar, sem listar
+		// cada tipo aqui.
+		std::cerr << "Error: " << e.what() << std::endl;
+		return (1);
+	}
 	return (0);
 }


### PR DESCRIPTION
Closes #2

Adds argument validation and the entry point of the server. Errors are reported
through exceptions caught in a single place, so no code path calls `exit()`.

**Validation**
* `validatePort()` accepts digits only, at most 5 of them, and a resulting value
  between 1024 and 65535. Rejects `-1`, `+6667`, `6667abc` and whitespace without
  extra checks, since none of those is a port. Returns the converted `int`, so
  parsing and validation happen in one pass.
* `validatePass()` rejects an empty password. Any other content is accepted: the
  subject imposes no format, and the client sends it verbatim via `PASS`.

**Error handling**
* Wrong argument count is handled before the `try` and prints the usage line.
  It is a user mistake, not a program error.
* Everything else throws `std::invalid_argument` with a specific message, caught
  by a single `catch (const std::exception&)` in `main` that prints to `stderr`
  and returns 1. This is the same handler that will later cover socket, bind and
  listen failures from the `Server` constructor.

**Not included**
* The `Server` construction and the `poll()` loop are commented out until #3
  lands on main. A temporary `std::cout` confirms the parsed values and is marked
  with a TODO for removal.

**Tested**
| Input | Result |
|---|---|
| no args / one arg / four args | usage line, exit 1 |
| `abc`, `-1024`, `+6667`, `65535abc` | digits-only error |
| `100000` | too long error |
| `80`, `1023`, `65536`, `99999`, `00000` | range error |
| empty password | password error |
| `1024`, `65535`, `01024` | accepted |
| `'abc 123!@#$%^'` as password | accepted |

Builds clean with `-Wall -Wextra -Werror -std=c++98`; a second `make` recompiles nothing.